### PR TITLE
update: add note to fix lint error on Windows

### DIFF
--- a/topic-labs/book-playtime-0-1-0/03.03.md
+++ b/topic-labs/book-playtime-0-1-0/03.03.md
@@ -199,3 +199,19 @@ Will run ESLint - reporting style violations to the console:
 
 If we still have the `let test = 1;` in our code then it is reported as above.
 
+**Note:** On Windows machines you may see the following error when running `npm run lint`:
+
+~~~bash
+'.' is not recognized as an internal or external command, operable program or batch file.
+~~~
+
+If so, replace the value for the "lint" value in the "scripts" config in `package.json` with the following: 
+
+~~~json
+  "scripts": {
+    "start": "node src/server.js",
+    "lint": "eslint . --ext .js"
+  },
+~~~
+
+...and re-run `npm run lint`


### PR DESCRIPTION
Add instructions on how to fix issue when running `npm run lint` on Windows machines.