### PR TITLE
fix: Amend track-model-tests test

### DIFF
--- a/topic-labs/book-playtime-0-6-0/01.01.md
+++ b/topic-labs/book-playtime-0-6-0/01.01.md
@@ -191,7 +191,7 @@ suite("Track Model tests", () => {
 
   test("get multiple tracks", async () => {
     const tracks = await db.trackStore.getTracksByPlaylistId(beethovenList._id);
-    assert.equal(testTracks.length, testTracks.length)
+    assert.equal(tracks.length, testTracks.length)
   });
 
   test("delete all tracks", async () => {


### PR DESCRIPTION
Amend assertion for 'delete one track success' test to compare returned tracks length with fixture tracks