### PR TITLE
fix: Update setup method on User API tests

### DIFF
--- a/topic-labs/book-playtime-0-6-0/06.06.md
+++ b/topic-labs/book-playtime-0-6-0/06.06.md
@@ -116,7 +116,7 @@ export const playtimeService = {
 
 We can extend our user API tests a little to exercise more features:
 
-## user-apis-test.js
+## user-api-test.js
 
 ~~~javascript
 import { assert } from "chai";
@@ -129,7 +129,7 @@ suite("User API tests", () => {
     await playtimeService.deleteAllUsers();
     for (let i = 0; i < testUsers.length; i += 1) {
       // eslint-disable-next-line no-await-in-loop
-      testUsers[0] = await playtimeService.createUser(testUsers[i]);
+      testUsers[i] = await playtimeService.createUser(testUsers[i]);
     }
   });
   teardown(async () => {


### PR DESCRIPTION
Use the current index to update the corresponding test user in the list instead of overwriting the first user.

Also update filename label in the instructions to correct name.